### PR TITLE
PR feature/feed/enum-property

### DIFF
--- a/src/main/kotlin/com/bee/newsfeed_bee/domain/feed/config/FeedConfig.kt
+++ b/src/main/kotlin/com/bee/newsfeed_bee/domain/feed/config/FeedConfig.kt
@@ -1,0 +1,25 @@
+package com.bee.newsfeed_bee.domain.feed.config
+
+import com.bee.newsfeed_bee.domain.feed.entity.CuisineCategory
+import org.springframework.context.annotation.Configuration
+import org.springframework.core.convert.converter.Converter
+import org.springframework.format.FormatterRegistry
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+@Configuration
+class FeedConfig : WebMvcConfigurer {
+
+    override fun addFormatters(registry: FormatterRegistry) {
+        registry.addConverter(CuisineCategoryConverter())
+    }
+
+    class CuisineCategoryConverter: Converter<String, CuisineCategory> {
+        override fun convert(source: String): CuisineCategory {
+            return kotlin.runCatching {
+                CuisineCategory.valueOf(source)
+            }.getOrElse { 
+                throw IllegalArgumentException("음식 카테고리 잘못 입력")
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/bee/newsfeed_bee/domain/feed/controller/FeedController.kt
+++ b/src/main/kotlin/com/bee/newsfeed_bee/domain/feed/controller/FeedController.kt
@@ -3,6 +3,7 @@ package com.bee.newsfeed_bee.domain.feed.controller
 import com.bee.newsfeed_bee.domain.feed.dto.FeedCreateRequest
 import com.bee.newsfeed_bee.domain.feed.dto.FeedResponse
 import com.bee.newsfeed_bee.domain.feed.dto.FeedUpdateRequest
+import com.bee.newsfeed_bee.domain.feed.entity.CuisineCategory
 import com.bee.newsfeed_bee.domain.feed.service.FeedService
 import jakarta.validation.Valid
 import org.springframework.data.domain.PageRequest
@@ -20,7 +21,7 @@ class FeedController(
 
     @GetMapping
     fun getFeedList(
-        @RequestParam(required = false) category: String?,
+        @RequestParam(required = false) category: CuisineCategory?,
         @RequestParam(required = false) address: String?,
         @RequestParam(name = "page", required = false, defaultValue = "1") pageNumber: Int,
     ): ResponseEntity<List<FeedResponse>> {

--- a/src/main/kotlin/com/bee/newsfeed_bee/domain/feed/dto/FeedCreateRequest.kt
+++ b/src/main/kotlin/com/bee/newsfeed_bee/domain/feed/dto/FeedCreateRequest.kt
@@ -1,5 +1,6 @@
 package com.bee.newsfeed_bee.domain.feed.dto
 
+import com.bee.newsfeed_bee.domain.feed.entity.CuisineCategory
 import jakarta.validation.constraints.Max
 import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotBlank
@@ -7,7 +8,7 @@ import java.time.OffsetDateTime
 
 data class FeedCreateRequest( // TODO API 명세와 프로퍼티 순서 다름
     @field:NotBlank(message = "storeName은 필수 입력 정보입니다.") val storeName: String,
-    val category: String,
+    val category: CuisineCategory,
     @field:NotBlank(message = "address는 필수 입력 정보입니다.") val address: String, // Address라는 객체를 만들 필요가 있지 않을까?
     @field:Min(1) @field:Max(5) val score: Int, // 정책적으로 결정할 부분 있음 // enum으로 만드는 편이 낫지 않을까?
     val visitedDateTime: OffsetDateTime,

--- a/src/main/kotlin/com/bee/newsfeed_bee/domain/feed/dto/FeedResponse.kt
+++ b/src/main/kotlin/com/bee/newsfeed_bee/domain/feed/dto/FeedResponse.kt
@@ -1,5 +1,6 @@
 package com.bee.newsfeed_bee.domain.feed.dto
 
+import com.bee.newsfeed_bee.domain.feed.entity.CuisineCategory
 import java.time.OffsetDateTime
 
 data class FeedResponse( // TODO API 명세와 프로퍼티 순서 다름
@@ -8,7 +9,7 @@ data class FeedResponse( // TODO API 명세와 프로퍼티 순서 다름
     val createdDateTime: OffsetDateTime,
     val lastModifiedDateTime: OffsetDateTime,
     val storeName: String, // TODO: 수정 가능한 속성에 대해서는 더 논의할 필요가 있음
-    val category: String,
+    val category: CuisineCategory,
     val address: String,
     val score: Int,
     val visitedDateTime: OffsetDateTime,

--- a/src/main/kotlin/com/bee/newsfeed_bee/domain/feed/dto/FeedUpdateRequest.kt
+++ b/src/main/kotlin/com/bee/newsfeed_bee/domain/feed/dto/FeedUpdateRequest.kt
@@ -1,5 +1,6 @@
 package com.bee.newsfeed_bee.domain.feed.dto
 
+import com.bee.newsfeed_bee.domain.feed.entity.CuisineCategory
 import jakarta.validation.constraints.Max
 import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotBlank
@@ -7,7 +8,7 @@ import java.time.OffsetDateTime
 
 data class FeedUpdateRequest( // TODO API 명세와 프로퍼티 순서 다름
     @NotBlank(message = "storeName은 필수 입력 정보입니다.") val storeName: String,
-    val category: String,
+    val category: CuisineCategory,
     @NotBlank(message = "address는 필수 입력 정보입니다.") val address: String, // Address라는 객체를 만들 필요가 있지 않을까?
     @Min(1) @Max(5) val score: Int, // 정책적으로 결정할 부분 있음 // enum으로 만드는 편이 낫지 않을까?
     val visitedDateTime: OffsetDateTime,

--- a/src/main/kotlin/com/bee/newsfeed_bee/domain/feed/entity/CuisineCategory.kt
+++ b/src/main/kotlin/com/bee/newsfeed_bee/domain/feed/entity/CuisineCategory.kt
@@ -1,6 +1,6 @@
 package com.bee.newsfeed_bee.domain.feed.entity
 
-enum class CuisineCategory(categoryKoreanName: String) {
+enum class CuisineCategory(val categoryKoreanName: String) {
     KOREAN("한식"),
     BUNSIK("분식"),
     CHINESE("중식"),

--- a/src/main/kotlin/com/bee/newsfeed_bee/domain/feed/entity/CuisineCategory.kt
+++ b/src/main/kotlin/com/bee/newsfeed_bee/domain/feed/entity/CuisineCategory.kt
@@ -1,0 +1,12 @@
+package com.bee.newsfeed_bee.domain.feed.entity
+
+enum class CuisineCategory(categoryKoreanName: String) {
+    KOREAN("한식"),
+    BUNSIK("분식"),
+    CHINESE("중식"),
+    JAPANESE("일식"),
+    WESTERN("양식"),
+    CAFE_AND_DESSERT("카페, 디저트"),
+    ASIAN("아시안"),
+    BARBECUE("고깃집");
+}

--- a/src/main/kotlin/com/bee/newsfeed_bee/domain/feed/entity/CuisineCategoryConverter.kt
+++ b/src/main/kotlin/com/bee/newsfeed_bee/domain/feed/entity/CuisineCategoryConverter.kt
@@ -1,0 +1,16 @@
+package com.bee.newsfeed_bee.domain.feed.entity
+
+import jakarta.persistence.AttributeConverter
+import jakarta.persistence.Converter
+
+@Converter(autoApply = true)
+class CuisineCategoryConverter: AttributeConverter<CuisineCategory, String> {
+
+    override fun convertToDatabaseColumn(enumName: CuisineCategory): String {
+        return enumName.categoryKoreanName
+    }
+
+    override fun convertToEntityAttribute(dbColumnValue: String): CuisineCategory {
+        return CuisineCategory.entries.first { it.categoryKoreanName == dbColumnValue }
+    }
+}

--- a/src/main/kotlin/com/bee/newsfeed_bee/domain/feed/entity/Feed.kt
+++ b/src/main/kotlin/com/bee/newsfeed_bee/domain/feed/entity/Feed.kt
@@ -4,10 +4,7 @@ import com.bee.newsfeed_bee.domain.feed.dto.FeedCreateRequest
 import com.bee.newsfeed_bee.domain.feed.dto.FeedResponse
 import com.bee.newsfeed_bee.domain.feed.dto.FeedUpdateRequest
 import com.bee.newsfeed_bee.util.jpaBaseEntity.BaseEntity
-import jakarta.persistence.Entity
-import jakarta.persistence.GeneratedValue
-import jakarta.persistence.GenerationType
-import jakarta.persistence.Id
+import jakarta.persistence.*
 import java.time.OffsetDateTime
 
 @Entity
@@ -15,7 +12,7 @@ class Feed( // TODO: 수정 가능한 속성에 대해서는 더 논의할 필�
     var deletedDateTime: OffsetDateTime?,
     val userId: Long, // TODO: User entity는 별도로 작업하고 있으므로 추후 User entity merge 시 변경할 것
     var storeName: String,
-    var cuisineCategory: CuisineCategory,
+    @Convert(converter = CuisineCategoryConverter::class) var category: CuisineCategory,
     var address: String,
     var score: Int,
     var visitedDateTime: OffsetDateTime,
@@ -36,7 +33,7 @@ fun Feed.toResponse(): FeedResponse {
         createdDateTime = this.createdDateTime,
         lastModifiedDateTime = this.lastModifiedDateTime,
         storeName = this.storeName,
-        category = this.cuisineCategory,
+        category = this.category,
         address = this.address,
         score = this.score,
         visitedDateTime = this.visitedDateTime,
@@ -48,7 +45,7 @@ fun Feed.toResponse(): FeedResponse {
 
 fun Feed.updateFrom(request: FeedUpdateRequest): Feed {
     this.storeName = request.storeName
-    this.cuisineCategory = request.category
+    this.category = request.category
     this.address = request.address
     this.score = request.score
     this.visitedDateTime = request.visitedDateTime
@@ -64,7 +61,7 @@ fun FeedCreateRequest.toEntity(): Feed {
         deletedDateTime = null,
         userId = 0, // TODO 현재 인증 관련 부분이 추가되지 않았기 때문에 임시로만 넣어둠
         storeName = this.storeName,
-        cuisineCategory = this.category,
+        category = this.category,
         address = this.address,
         score = this.score,
         visitedDateTime = this.visitedDateTime,

--- a/src/main/kotlin/com/bee/newsfeed_bee/domain/feed/entity/Feed.kt
+++ b/src/main/kotlin/com/bee/newsfeed_bee/domain/feed/entity/Feed.kt
@@ -14,13 +14,13 @@ import java.time.OffsetDateTime
 class Feed( // TODO: 수정 가능한 속성에 대해서는 더 논의할 필요가 있음
     var deletedDateTime: OffsetDateTime?,
     val userId: Long, // TODO: User entity는 별도로 작업하고 있으므로 추후 User entity merge 시 변경할 것
-    var storeName: String, // store
-    var category: String, // cuisineType? // enum // store
-    var address: String, // store
+    var storeName: String,
+    var cuisineCategory: CuisineCategory,
+    var address: String,
     var score: Int,
     var visitedDateTime: OffsetDateTime,
     var waited: Boolean,
-    var storeSize: Int, // enum
+    var storeSize: Int, // enum?
     var content: String,
 ) : BaseEntity() {
 
@@ -36,7 +36,7 @@ fun Feed.toResponse(): FeedResponse {
         createdDateTime = this.createdDateTime,
         lastModifiedDateTime = this.lastModifiedDateTime,
         storeName = this.storeName,
-        category = this.category,
+        category = this.cuisineCategory,
         address = this.address,
         score = this.score,
         visitedDateTime = this.visitedDateTime,
@@ -48,7 +48,7 @@ fun Feed.toResponse(): FeedResponse {
 
 fun Feed.updateFrom(request: FeedUpdateRequest): Feed {
     this.storeName = request.storeName
-    this.category = request.category
+    this.cuisineCategory = request.category
     this.address = request.address
     this.score = request.score
     this.visitedDateTime = request.visitedDateTime
@@ -64,7 +64,7 @@ fun FeedCreateRequest.toEntity(): Feed {
         deletedDateTime = null,
         userId = 0, // TODO 현재 인증 관련 부분이 추가되지 않았기 때문에 임시로만 넣어둠
         storeName = this.storeName,
-        category = this.category,
+        cuisineCategory = this.category,
         address = this.address,
         score = this.score,
         visitedDateTime = this.visitedDateTime,

--- a/src/main/kotlin/com/bee/newsfeed_bee/domain/feed/repository/CustomFeedRepository.kt
+++ b/src/main/kotlin/com/bee/newsfeed_bee/domain/feed/repository/CustomFeedRepository.kt
@@ -1,9 +1,10 @@
 package com.bee.newsfeed_bee.domain.feed.repository
 
+import com.bee.newsfeed_bee.domain.feed.entity.CuisineCategory
 import com.bee.newsfeed_bee.domain.feed.entity.Feed
 import org.springframework.data.domain.Pageable
 
 interface CustomFeedRepository {
 
-    fun findAllByCategoryDongDeletedDateTime(category: String?, address: String?, pageable: Pageable): List<Feed>
+    fun findAllByCategoryAddressDeletedDateTime(category: CuisineCategory?, address: String?, pageable: Pageable): List<Feed>
 }

--- a/src/main/kotlin/com/bee/newsfeed_bee/domain/feed/repository/CustomFeedRepositoryImpl.kt
+++ b/src/main/kotlin/com/bee/newsfeed_bee/domain/feed/repository/CustomFeedRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package com.bee.newsfeed_bee.domain.feed.repository
 
+import com.bee.newsfeed_bee.domain.feed.entity.CuisineCategory
 import com.bee.newsfeed_bee.domain.feed.entity.Feed
 import com.bee.newsfeed_bee.domain.feed.entity.QFeed
 import com.bee.newsfeed_bee.util.queryDsl.QueryDslSupport
@@ -9,7 +10,7 @@ class CustomFeedRepositoryImpl : CustomFeedRepository, QueryDslSupport() {
 
     private val feed = QFeed.feed
 
-    override fun findAllByCategoryDongDeletedDateTime(category: String?, address: String?, pageable: Pageable): List<Feed> {
+    override fun findAllByCategoryAddressDeletedDateTime(category: CuisineCategory?, address: String?, pageable: Pageable): List<Feed> {
         return queryFactory.selectFrom(feed)
             .let { if (category != null) it.where(feed.category.eq(category)) else it }
             .let { if (address != null) it.where(feed.address.contains(address)) else it }

--- a/src/main/kotlin/com/bee/newsfeed_bee/domain/feed/service/FeedService.kt
+++ b/src/main/kotlin/com/bee/newsfeed_bee/domain/feed/service/FeedService.kt
@@ -3,6 +3,7 @@ package com.bee.newsfeed_bee.domain.feed.service
 import com.bee.newsfeed_bee.domain.feed.dto.FeedCreateRequest
 import com.bee.newsfeed_bee.domain.feed.dto.FeedResponse
 import com.bee.newsfeed_bee.domain.feed.dto.FeedUpdateRequest
+import com.bee.newsfeed_bee.domain.feed.entity.CuisineCategory
 import com.bee.newsfeed_bee.domain.feed.entity.toEntity
 import com.bee.newsfeed_bee.domain.feed.entity.toResponse
 import com.bee.newsfeed_bee.domain.feed.entity.updateFrom
@@ -16,13 +17,8 @@ import java.time.OffsetDateTime
 class FeedService(
     private val feedRepository: FeedRepository
 ) {
-    fun getFeedList(category: String?, address: String?, pageable: Pageable): List<FeedResponse> {
-//        return if (category == null) {
-//            feedRepository.findAllByDeletedDateTimeIsNull(pageable).map { it.toResponse() }
-//        } else {
-//            feedRepository.findAllByCategoryAndDeletedDateTimeIsNull(category, pageable).map { it.toResponse() }
-//        }
-        return feedRepository.findAllByCategoryDongDeletedDateTime(category, address, pageable).map { it.toResponse() }
+    fun getFeedList(category: CuisineCategory?, address: String?, pageable: Pageable): List<FeedResponse> {
+        return feedRepository.findAllByCategoryAddressDeletedDateTime(category, address, pageable).map { it.toResponse() }
     }
 
     fun getFeed(feedId: Long): FeedResponse {


### PR DESCRIPTION
- Feed 엔티티의 category 프로퍼티를 enum class 타입으로 변경
  - 이에 따라 영향 받는 다른 코드들 변경(DTO 등)
  - 적용 위해 컨버터 추가 
    - 요청값을 바인딩하기 위해 앞쪽에서도 컨버터가 필요
    - DB 쪽에서는 enum의 name이 아니라 property를 사용해서 저장하기 위해 컨버터가 필요
  - 이에 따른 controller, repository 변경