### PR TITLE
Feature/reply/validaion 예외 검증 처리 추가

### DIFF
--- a/src/main/kotlin/com/bee/newsfeed_bee/domain/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/bee/newsfeed_bee/domain/exception/GlobalExceptionHandler.kt
@@ -35,4 +35,10 @@ class GlobalExceptionHandler {
             .body(ErrorResponse(message = e.message))
     }
 
+    @ExceptionHandler(InputRangeException::class)
+    fun handleInputRangeException(e: InputRangeException) : ResponseEntity<ErrorResponse>{
+        return ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body(ErrorResponse(message = e.message))
+    }
 }

--- a/src/main/kotlin/com/bee/newsfeed_bee/domain/exception/InputRangeException.kt
+++ b/src/main/kotlin/com/bee/newsfeed_bee/domain/exception/InputRangeException.kt
@@ -1,0 +1,5 @@
+package com.bee.newsfeed_bee.domain.exception
+
+data class InputRangeException(val field:String, val len:Int, val min:Int, val max:Int):RuntimeException(
+    "$field value($len) must between $min and $max"
+)

--- a/src/main/kotlin/com/bee/newsfeed_bee/domain/feed/entity/Feed.kt
+++ b/src/main/kotlin/com/bee/newsfeed_bee/domain/feed/entity/Feed.kt
@@ -1,8 +1,11 @@
 package com.bee.newsfeed_bee.domain.feed.entity
 
+import com.bee.newsfeed_bee.domain.exception.InputLengthException
+import com.bee.newsfeed_bee.domain.exception.InputRangeException
 import com.bee.newsfeed_bee.domain.feed.dto.FeedCreateRequest
 import com.bee.newsfeed_bee.domain.feed.dto.FeedResponse
 import com.bee.newsfeed_bee.domain.feed.dto.FeedUpdateRequest
+import com.bee.newsfeed_bee.domain.reply.entity.Reply
 import com.bee.newsfeed_bee.util.jpaBaseEntity.BaseEntity
 import jakarta.persistence.*
 import java.time.OffsetDateTime
@@ -24,6 +27,17 @@ class Feed( // TODO: 수정 가능한 속성에 대해서는 더 논의할 필�
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     var id: Long? = null
+
+    init{
+        validate()
+    }
+    companion object{
+        const val STORENAME_MAX = 25
+        const val CATEGORY_MAX = 100
+        const val ADDRESS_MAX = 100
+        const val SCORE_MAX = 5
+        const val CONTENT_MAX = 500
+    }
 }
 
 fun Feed.toResponse(): FeedResponse {
@@ -55,6 +69,19 @@ fun Feed.updateFrom(request: FeedUpdateRequest): Feed {
 
     return this
 }
+
+fun Feed.validate() {
+    if (this.storeName.isEmpty() || this.storeName.length > Feed.STORENAME_MAX)
+        throw InputLengthException("UserName",storeName.length,1, Feed.STORENAME_MAX)
+    if (this.address.isEmpty() || this.address.length > Feed.ADDRESS_MAX)
+        throw InputLengthException("Address",address.length,1, Feed.ADDRESS_MAX)
+    if (this.score < 1 || this.score > 5)
+        throw InputRangeException("Score",score,1, Feed.SCORE_MAX)
+    if (this.content.isEmpty() || this.content.length > Feed.CONTENT_MAX)
+        throw InputLengthException("Content",content.length,1, Feed.CONTENT_MAX)
+}
+
+
 
 fun FeedCreateRequest.toEntity(): Feed {
     return Feed(

--- a/src/main/kotlin/com/bee/newsfeed_bee/domain/feed/service/FeedService.kt
+++ b/src/main/kotlin/com/bee/newsfeed_bee/domain/feed/service/FeedService.kt
@@ -3,10 +3,7 @@ package com.bee.newsfeed_bee.domain.feed.service
 import com.bee.newsfeed_bee.domain.feed.dto.FeedCreateRequest
 import com.bee.newsfeed_bee.domain.feed.dto.FeedResponse
 import com.bee.newsfeed_bee.domain.feed.dto.FeedUpdateRequest
-import com.bee.newsfeed_bee.domain.feed.entity.CuisineCategory
-import com.bee.newsfeed_bee.domain.feed.entity.toEntity
-import com.bee.newsfeed_bee.domain.feed.entity.toResponse
-import com.bee.newsfeed_bee.domain.feed.entity.updateFrom
+import com.bee.newsfeed_bee.domain.feed.entity.*
 import com.bee.newsfeed_bee.domain.feed.repository.FeedRepository
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
@@ -27,13 +24,16 @@ class FeedService(
 
     fun createFeed(feedCreateRequest: FeedCreateRequest): FeedResponse {
         return feedCreateRequest.toEntity()
-            .let { feedRepository.save(it) }.toResponse()
+            .also{it.validate()}
+            .let { feedRepository.save(it) }
+            .toResponse()
     }
 
     @Transactional
     fun updateFeed(feedId: Long, feedUpdateRequest: FeedUpdateRequest): FeedResponse {
         return feedRepository.findByIdAndDeletedDateTimeIsNull(feedId) // TODO EmptyResultDataAccessException 처리
             .updateFrom(feedUpdateRequest)
+            .also{it.validate()}
             .toResponse()
     }
 

--- a/src/main/kotlin/com/bee/newsfeed_bee/domain/reply/entity/Reply.kt
+++ b/src/main/kotlin/com/bee/newsfeed_bee/domain/reply/entity/Reply.kt
@@ -39,16 +39,7 @@ class Reply(
     init{
         validate()
     }
-    fun validate(){
-        if(userName.isEmpty() || userName.length > USERNAME_MAX)
-            throw InputLengthException("UserName",userName.length,1,USERNAME_MAX)
 
-        if(password.length < 4 || password.length > PASSWORD_MAX)
-            throw InputLengthException("Password",password.length,PASSWORD_MIN,PASSWORD_MAX)
-
-        if(content.isEmpty() || content.length > CONTENT_MAX)
-            throw InputLengthException("Content",content.length,1,CONTENT_MAX)
-    }
 
     companion object{
         const val USERNAME_MAX = 20
@@ -58,6 +49,16 @@ class Reply(
     }
 }
 
+fun Reply.validate(){
+    if(userName.isEmpty() || userName.length > Reply.USERNAME_MAX)
+        throw InputLengthException("UserName",userName.length,1, Reply.USERNAME_MAX)
+
+    if(password.length < 4 || password.length > Reply.PASSWORD_MAX)
+        throw InputLengthException("Password",password.length, Reply.PASSWORD_MIN, Reply.PASSWORD_MAX)
+
+    if(content.isEmpty() || content.length > Reply.CONTENT_MAX)
+        throw InputLengthException("Content",content.length,1, Reply.CONTENT_MAX)
+}
 
 fun Reply.toResponse(): ReplyResponse {
     return ReplyResponse(
@@ -71,5 +72,5 @@ fun Reply.toResponse(): ReplyResponse {
 
 fun Reply.chkPassword(input:String){
     if(this.password != input)
-            throw InvalidCredentialsException("Password","Reply")
+        throw InvalidCredentialsException("Password","Reply")
 }

--- a/src/main/kotlin/com/bee/newsfeed_bee/domain/reply/entity/Reply.kt
+++ b/src/main/kotlin/com/bee/newsfeed_bee/domain/reply/entity/Reply.kt
@@ -14,11 +14,15 @@ import java.time.OffsetDateTime
 //@Table(name = "feed")
 
 class Reply(
-    _userName : String,
+    @Column(name="user_name")
+    var userName : String,
 
-    _password : String,
+    @JsonIgnore
+    @Column(name = "password")
+    var password : String,
 
-    _content : String,
+    @Column(name = "content")
+    var content : String,
 
     @Column
     var deletedDateTime: OffsetDateTime? = null,
@@ -32,24 +36,19 @@ class Reply(
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     var id:Long?=null
 
-    @Column(name="user_name")
-    var userName = _userName
-        .also{if(it.isEmpty() || it.length > USERNAME_MAX)
-            throw InputLengthException("UserName",_userName.length,1,USERNAME_MAX)
-        }
+    init{
+        validate()
+    }
+    fun validate(){
+        if(userName.isEmpty() || userName.length > USERNAME_MAX)
+            throw InputLengthException("UserName",userName.length,1,USERNAME_MAX)
 
-    @JsonIgnore
-    @Column(name = "password")
-    var password = _password
-        .also{if(it.length < 4 || it.length > PASSWORD_MAX)
-            throw InputLengthException("Password",_password.length,PASSWORD_MIN,PASSWORD_MAX)
-        }
+        if(password.length < 4 || password.length > PASSWORD_MAX)
+            throw InputLengthException("Password",password.length,PASSWORD_MIN,PASSWORD_MAX)
 
-    @Column(name = "content")
-    var content = _content
-        .also{if(it.isEmpty() || it.length > CONTENT_MAX)
-            throw InputLengthException("Content",_content.length,1,CONTENT_MAX)
-        }
+        if(content.isEmpty() || content.length > CONTENT_MAX)
+            throw InputLengthException("Content",content.length,1,CONTENT_MAX)
+    }
 
     companion object{
         const val USERNAME_MAX = 20

--- a/src/main/kotlin/com/bee/newsfeed_bee/domain/reply/service/ReplyServiceImpl.kt
+++ b/src/main/kotlin/com/bee/newsfeed_bee/domain/reply/service/ReplyServiceImpl.kt
@@ -9,6 +9,7 @@ import com.bee.newsfeed_bee.domain.reply.dto.ReplyUpdateRequest
 import com.bee.newsfeed_bee.domain.reply.entity.Reply
 import com.bee.newsfeed_bee.domain.reply.entity.chkPassword
 import com.bee.newsfeed_bee.domain.reply.entity.toResponse
+import com.bee.newsfeed_bee.domain.reply.entity.validate
 import com.bee.newsfeed_bee.domain.reply.repository.ReplyRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -54,8 +55,6 @@ class ReplyServiceImpl(
         reply.chkPassword(request.password)
 
         reply.content = request.contents
-
-        reply.validate()
 
         return reply.toResponse()
     }

--- a/src/main/kotlin/com/bee/newsfeed_bee/domain/reply/service/ReplyServiceImpl.kt
+++ b/src/main/kotlin/com/bee/newsfeed_bee/domain/reply/service/ReplyServiceImpl.kt
@@ -37,11 +37,12 @@ class ReplyServiceImpl(
         val feed = feedRepository.findByIdAndDeletedDateTimeIsNull(feedId)
             ?: throw ModelNotFoundException("Feed",feedId)
         return Reply(
-            _userName = request.userName,
-            _password = request.password,
-            _content = request.contents,
+            userName = request.userName,
+            password = request.password,
+            content = request.contents,
             feed = feed
-        ).let{replyRepository.save(it)}.toResponse()
+        ).also{it.validate()}
+            .let{replyRepository.save(it)}.toResponse()
 
     }
 
@@ -53,6 +54,8 @@ class ReplyServiceImpl(
         reply.chkPassword(request.password)
 
         reply.content = request.contents
+
+        reply.validate()
 
         return reply.toResponse()
     }


### PR DESCRIPTION
기존의 방식으론 Create 할 때엔 정상적으로 기능하나  
Update 시 파라미터의 검증과정이 생략되어 validate() 메서드를 추가하였습니다.

이 메서드는 객체의 Service의 Create, Update 과정에서 호출되어 각 파라미터의 유효성을 검사하고 
해당하는 오류처리를 진행합니다.

close #9 